### PR TITLE
Persistent checkboxes and skip to card functionality added

### DIFF
--- a/client/components/Board.jsx
+++ b/client/components/Board.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Grid from '@material-ui/core/Grid';
 import Card from './Card.jsx';
-import { selectBoard, complete, grabTechFromCompletePile } from '../reducers/boardSlice';
+import { selectBoard, increment, decrement } from '../reducers/boardSlice';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 
@@ -16,17 +16,15 @@ const Board = (props) => {
   const { id } = props;
 
   const dispatch = useDispatch();
-  console.log('use selector', useSelector(selectBoard));
   const { boardState } = useSelector(selectBoard);
   const { current } = boardState;
-  console.log('current', current);
   const classes = useStyles();
   const cardsArr = [];
 
   if (id === 'stack')
-    boardState.cards.forEach((card, idx) =>
-      cardsArr.push(<Card key={idx} name={card.name} />, <br />)
-    );
+    for (let i = current + 1; i < boardState.cards.length; i += 1) {
+      cardsArr.push(<Card key={i} name={boardState.cards[i].name} />, <br />);
+    }
 
   if (id === 'inProgress' && boardState.cards[current]) {
     cardsArr.push(
@@ -38,16 +36,18 @@ const Board = (props) => {
           url={boardState.cards[current].url}
           card={boardState.cards[current]}
         />
-        <Button onClick={() => dispatch(complete())}>Card Complete</Button>
+        <Button onClick={() => dispatch(increment())}>Card Complete</Button>
       </div>
     );
   }
 
   if (id === 'complete') {
-    for (let i = 0; i < boardState.done.length; i++) {
-      cardsArr.push(<Card key={i} name={boardState.done[i].name} />, <br />);
+    for (let i = 0; i < current; i++) {
+      cardsArr.push(<Card key={i} name={boardState.cards[i].name} />, <br />);
     }
-    cardsArr.push(<Button onClick={() => dispatch(grabTechFromCompletePile())}>Go Back</Button>)
+    cardsArr.push(
+      <Button onClick={() => dispatch(decrement())}>Go Back</Button>
+    );
   }
   return (
     <div>

--- a/client/components/Card.jsx
+++ b/client/components/Card.jsx
@@ -4,6 +4,8 @@ import Task from './Task';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
+import { useDispatch } from 'react-redux';
+import { skipToCard } from '../reducers/boardSlice';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -30,6 +32,8 @@ const useStyles = makeStyles((theme) => ({
 const Card = (props) => {
   //props only has card if we're in the "in progress board"
   const { card = null, name, url } = props;
+  const dispatch = useDispatch();
+  console.log('in card - card', card);
 
   const classes = useStyles();
 
@@ -43,16 +47,23 @@ const Card = (props) => {
             name={todo[i].taskName}
             detail={todo[i].details}
             complete={todo[i].completed}
-            id={`id${i}`}
+            id={`${name}-${i}`}
           />
         </div>
       );
     }
   }
+
+  const handleTitleClick = (e) => {
+    dispatch(skipToCard({ targetTech: e.target.innerText }));
+  };
+
   return (
     <div className={classes.root}>
       <Paper className={classes.paper}>
-        <Typography className={classes.heading}>{name}</Typography>
+        <Typography className={classes.heading} onClick={handleTitleClick}>
+          {name}
+        </Typography>
         <br />
         <a href={url} target="_blank">
           <em>{url}</em>

--- a/client/components/Task.jsx
+++ b/client/components/Task.jsx
@@ -5,6 +5,8 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import Checkbox from '@material-ui/core/Checkbox';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { useDispatch } from 'react-redux';
+import { completeTask } from '../reducers/boardSlice';
 const themes = createMuiTheme({
   palette: {
     primary: {
@@ -32,35 +34,46 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Task = (props) => {
+  let { name, detail, complete, id } = props;
   const classes = useStyles();
+  const dispatch = useDispatch();
 
   return (
     <List dense className={classes.root}>
       <ListItem className={classes.name}>
         <ListItemSecondaryAction>
-          <Checkbox
-            defaultUnchecked
-            color="secondary"
-            inputProps={{ 'aria-label': 'checkbox with default color' }}
-            onClick={() => {
-
-
-              if (document.querySelector(`#${props.id}`).style.textDecoration === 'line-through') {
-                document.querySelector(`#${props.id}`).style.textDecoration = 'none';
-                // set completed to false
-              } else {
-                document.querySelector(`#${props.id}`).style.textDecoration = 'line-through';
-
-                // set completed to true
-              }
-            }}
-          />
+          {complete ? (
+            <Checkbox
+              defaultChecked
+              color="secondary"
+              inputProps={{ 'aria-label': 'checkbox with default color' }}
+              onClick={() => {
+                dispatch(completeTask({ todoName: name }));
+              }}
+            />
+          ) : (
+            <Checkbox
+              defaultUnchecked
+              color="secondary"
+              inputProps={{ 'aria-label': 'checkbox with default color' }}
+              onClick={() => {
+                dispatch(completeTask({ todoName: name }));
+              }}
+            />
+          )}
         </ListItemSecondaryAction>
         <strong>{props.name}</strong>
       </ListItem>
       <ListItem button className={classes.detail}>
-        <span id={props.id}>{props.detail}</span>
-
+        <span
+          style={
+            complete
+              ? { textDecoration: 'line-through' }
+              : { textDecoration: 'none' }
+          }
+        >
+          {props.detail}
+        </span>
 
         {props.complete}
       </ListItem>

--- a/client/reducers/boardSlice.js
+++ b/client/reducers/boardSlice.js
@@ -9,19 +9,16 @@ export const boardSlice = createSlice({
     current: 0, //index of current card
     username: '',
     cards: [], // an array of card objects filled from the deck
-    done: []
   },
   reducers: {
-    complete: (state) => {
-      let keep = state.cards[0]
-      state.cards.shift();
-      state.done.push(keep)
+    increment: (state) => {
+      state.current += 1;
     },
-    grabTechFromCompletePile : (state) => {
-      let keep = state.done[state.done.length-1]
-      state.done.pop()
-      state.cards.unshift(keep)
+
+    decrement: (state) => {
+      if (state.current >= 0) state.current -= 1;
     },
+
     addCard: (state, action) => {
       state.cards.push(action.payload);
     },
@@ -39,17 +36,41 @@ export const boardSlice = createSlice({
       state.current = action.payload.current;
       state.cards = action.payload.cards;
     },
+
+    skipToCard: (state, action) => {
+      const { targetTech } = action.payload;
+      const newCurrent = state.cards.findIndex(
+        (card) => card.name === targetTech
+      );
+      state.current = newCurrent;
+    },
+
+    completeTask: (state, action) => {
+      //will receive todoName in payload
+      //look at cards[current] object for todo array
+      //iterate through todo array and look for object with a name value === todoName from payload
+      //set completed = !completed
+      const { todoName } = action.payload;
+      const currentCard = state.cards[state.current];
+      const currentTodos = currentCard.todo;
+      currentTodos.forEach((todo) => {
+        if (todo.taskName === todoName) todo.completed = !todo.completed;
+      });
+    },
   },
 });
 
 export const {
-  grabTechFromCompletePile,
   addCard,
   getAll,
   complete,
   getCards,
   assignUser,
   newState,
+  increment,
+  decrement,
+  completeTask,
+  skipToCard,
 } = boardSlice.actions;
 
 export const selectBoard = (state) => state;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Users were previously unable to go to any card they wanted (they had to cycle through each card to get to the one they want). 
Also the individual status of the todo items in each card did not persist between card changes. 
## Approach
<!--- How does your change address the problem? -->
Now added functionality where they can skip to whichever card they want in either the 'stack' or 'complete' column by clicking on the card title. Added additional reducers to handle that as well as keeping track of todo completion status. 
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![2d8ce013123f86aa52b5b5c784436cda](https://user-images.githubusercontent.com/64433815/88864946-51d19280-d1bb-11ea-8369-79e65d3ddf43.gif)
